### PR TITLE
'addFile' support bytes content

### DIFF
--- a/python/webgme_bindings/webgme_bindings/pluginbase.py
+++ b/python/webgme_bindings/webgme_bindings/pluginbase.py
@@ -1,3 +1,5 @@
+import base64
+
 from .webgme import WebGME
 from .exceptions import JSError, CoreIllegalArgumentError, CoreIllegalOperationError, CoreInternalError
 
@@ -112,12 +114,17 @@ class PluginBase(object):
         :param name: The name the file should be uploaded as.
         :type name: str
         :param content: The file content.
-        :type content: str
+        :type content: Union[str, bytes]
         :returns: The metadata-hash (the "id") of the uploaded file.
         :rtype: str
         :raises JSError: The result of the execution.
         """
-        return self._send({'name': 'addFile', 'args': [name, content]})
+        if isinstance(content, bytes):
+            content = base64.b64encode(content).decode("UTF-8")
+            is_bytes = True
+        else:
+            is_bytes = False
+        return self._send({'name': 'addFile', 'args': [name, content, is_bytes]})
 
     def create_message(self, node, message, severity='info'):
         """

--- a/src/corezmq.js
+++ b/src/corezmq.js
@@ -766,7 +766,7 @@ function CoreZMQ(project, core, mainLogger, opts) {
                     if (req.args.length == 2) {
                         // -> addArtifact
                     }else{
-                        is_bytes = req.args[2] // boolean
+                        const is_bytes = req.args[2] // boolean
                         if (is_bytes) {
                             data = Buffer.from(req.args[1], 'base64')
                         }else{

--- a/src/corezmq.js
+++ b/src/corezmq.js
@@ -761,6 +761,22 @@ function CoreZMQ(project, core, mainLogger, opts) {
                     return Q.reject(e);
                 }
             case 'addFile':
+                try {
+                    // compaitable with add_file(name, content)
+                    if (req.args.length == 2) {
+                        // -> addArtifact
+                    }else{
+                        is_bytes = req.args[2] // boolean
+                        if (is_bytes) {
+                            data = Buffer.from(req.args[1], 'base64')
+                        }else{
+                            data = req.args[1]
+                        }
+                        return plugin[req.name](req.args[0], data);
+                    }
+                } catch (e) {
+                    return Q.reject(e);
+                }
             case 'addArtifact':
                 try {
                     return plugin[req.name](req.args[0], req.args[1]);

--- a/src/corezmq.js
+++ b/src/corezmq.js
@@ -767,6 +767,7 @@ function CoreZMQ(project, core, mainLogger, opts) {
                         // -> addArtifact
                     }else{
                         const is_bytes = req.args[2] // boolean
+                        let data;
                         if (is_bytes) {
                             data = Buffer.from(req.args[1], 'base64')
                         }else{


### PR DESCRIPTION

The payload of request will be dumped as json, so the `addFile` method cannot receive the bytes content.

```python
json.dumps(payload)
```

To solve this problem, add the `is_bytes` parameter to the addFile method.

Changes is Backward compatible.